### PR TITLE
Feat/duration

### DIFF
--- a/specs/parser/duration.parser.spec.ts
+++ b/specs/parser/duration.parser.spec.ts
@@ -1,0 +1,27 @@
+import { duration } from '../../src/parser/duration.parser';
+
+describe('duration parser', () => {
+  it('should return a date adding the specified min/max duration', () => {
+    // arrange
+    const date = new Date(2019, 11, 1, 13, 0, 0);
+    const expectedDate = new Date(2019, 11, 1, 13, 1, 0);
+
+    // act
+    const futureDate = duration(date, [1, 'minutes'], [1, 'minutes']);
+
+    // assert
+    expect(futureDate).toEqual(expectedDate);
+  });
+
+  it('should accept negative duration', () => {
+    // arrange
+    const date = new Date(2019, 11, 1, 13, 1, 0);
+    const expectedDate = new Date(2019, 11, 1, 13, 0, 0);
+
+    // act
+    const futureDate = duration(date, [-1, 'minutes'], [-1, 'minutes']);
+
+    // assert
+    expect(futureDate).toEqual(expectedDate);
+  });
+});

--- a/specs/processors/map.spec.ts
+++ b/specs/processors/map.spec.ts
@@ -5,7 +5,7 @@ import { includeProcessorFnSpecs } from '../spec-helpers/shared-specs';
 describe('map processor fn', () => {
   it('should call the mapFn with the buildable it is located on', () => {
     // arrange
-    const mapFn = jasmine.createSpy('mapFn', v => v).and.callThrough();
+    const mapFn = jasmine.createSpy('mapFn', (v, _) => v).and.callThrough();
     const value = 42;
     const mapProcessor = map(mapFn);
     const buildable = createBuildable(value, [mapProcessor]);
@@ -15,7 +15,7 @@ describe('map processor fn', () => {
 
     // assert
     expect(mapFn).toHaveBeenCalledTimes(1);
-    expect(mapFn).toHaveBeenCalledWith(buildable);
+    expect(mapFn).toHaveBeenCalledWith(buildable, jasmine.any(Object));
   });
 
   it('should write the mapped value onto the node as value', () => {

--- a/src/builders/ref.ts
+++ b/src/builders/ref.ts
@@ -1,6 +1,6 @@
 import { findNode, ObjectTreeNode } from 'treelike';
 import { ProcessorOrders } from '../constants';
-import { Buildable, BuildableSymbol, createProcessorFn, ProcessorFn } from '../core';
+import { Buildable, BuildableSymbol, createProcessorFn, isBuildable, ProcessorFn } from '../core';
 import { isDefined, isUndefined } from '../util';
 export function ref<T = any>(propertyName: keyof T, ...processors: ProcessorFn[]): Buildable<any> {
   const refProcessor = createProcessorFn(refImpl, 'finalizer', ProcessorOrders.ref);
@@ -22,7 +22,9 @@ export function ref<T = any>(propertyName: keyof T, ...processors: ProcessorFn[]
       console.warn(`faketastic: Could not resolve reference to "${propertyName}"`);
     } else {
       node.children = [];
-      node.value = resolvedReference.value;
+      node.value = isBuildable(resolvedReference.value)
+        ? resolvedReference.value.value
+        : resolvedReference.value;
     }
   }
 }

--- a/src/parser/duration.parser.ts
+++ b/src/parser/duration.parser.ts
@@ -1,0 +1,46 @@
+import moment from 'moment';
+import { randomDate } from '../core';
+import { isArray } from '../util';
+
+type TimeUnit = 'hours' | 'minutes' | 'seconds';
+type DurationInput = [number, TimeUnit];
+
+// TODO: langju: think of a better place/name, as this might be slightly more than a "parser"?
+export function duration(
+  baseDate: Date,
+  minDuration: DurationInput,
+  maxDuration: DurationInput = [2, 'hours'],
+): Date | null {
+  try {
+    const min = getDurationAndFormat(minDuration);
+    const max = getDurationAndFormat(maxDuration);
+
+    const durationMin = moment.duration(min.duration, min.unit);
+    const durationMax = moment.duration(max.duration, max.unit);
+    const minDate = moment(baseDate)
+      .add(durationMin)
+      .toDate();
+    const maxDate = moment(baseDate)
+      .add(durationMax)
+      .toDate();
+
+    return randomDate(minDate, maxDate);
+  } catch {
+    return null;
+  }
+}
+
+function getDurationAndFormat(input: DurationInput) {
+  let unit: TimeUnit = 'hours';
+  let duration = 2;
+
+  if (isArray(input)) {
+    duration = input[0];
+
+    if (input.length >= 2) {
+      unit = input[1];
+    }
+  }
+
+  return { duration, unit };
+}

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,2 +1,3 @@
 export * from './date-time.parser';
+export * from './duration.parser';
 export * from './try-parse.fn';

--- a/src/processors/map.ts
+++ b/src/processors/map.ts
@@ -2,11 +2,11 @@ import { ObjectTreeNode } from 'treelike';
 import { ProcessorOrders } from '../constants/processor.orders';
 import { createProcessorFn, ProcessorFn } from '../core';
 
-export function map<T = any, K = any>(mapFn: (param: T) => K): ProcessorFn {
+export function map<T = any, K = any>(mapFn: (param: T, node?: ObjectTreeNode) => K): ProcessorFn {
   return createProcessorFn(mapImpl, 'finalizer', ProcessorOrders.map);
 
   function mapImpl(node: ObjectTreeNode) {
-    const mapped = mapFn(node.value);
+    const mapped = mapFn(node.value, node);
     node.value = mapped;
   }
 }


### PR DESCRIPTION
**Added**
- `duration(base: Date, min: DurationInput, max: DurationInput)` parser to allow generating future or past dates based on min/max durations.

**Changed**

- map will now optionally provide the node on which it runs